### PR TITLE
bindings: reduce the code smell

### DIFF
--- a/include/private/node/async.hpp
+++ b/include/private/node/async.hpp
@@ -1,8 +1,8 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software under the BSD license. See AUTHORS
 // and LICENSE for more information on the copying conditions.
-#ifndef PRIVATE_NODE_UV_ASYNC_CTX_HPP
-#define PRIVATE_NODE_UV_ASYNC_CTX_HPP
+#ifndef PRIVATE_NODE_SYNC_HPP
+#define PRIVATE_NODE_SYNC_HPP
 
 #include "private/common/compat.hpp"
 #include <list>

--- a/include/private/node/nettest_wrap.hpp
+++ b/include/private/node/nettest_wrap.hpp
@@ -17,6 +17,9 @@ namespace node {
 /// The NettestWrap class template is the Node-visible object. It wraps
 /// a mk::nettest::<T> test instance and uses a mk::node::UvAsyncCtx<> context
 /// to safely route test callbacks to libuv I/O loop (i.e. Node loop).
+///
+/// It is a class with static methods because that's the way in which things
+/// are organized in Node.js.
 template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
   public:
     /// ## Constructors
@@ -119,8 +122,8 @@ template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
     }
 
     /// NettestWrap() is the C++ constructor. It creates an instance of the
-    /// UvAsyncCtx<> context to route callbacks from C++ to Node.
-    NettestWrap() { async_ctx = UvAsyncCtx<>::make(); }
+    /// async::Context context to route callbacks from C++ to Node.
+    NettestWrap() { async_ctx = async::make<>(); }
 
     /// ## Value Setters
 
@@ -196,7 +199,7 @@ template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
             self->nettest.on_begin([
                 async_ctx = self->async_ctx, callback = wrap_callback(info[0])
             ]() {
-                UvAsyncCtx<>::suspend(async_ctx, [callback]() {
+                async::suspend<>(async_ctx, [callback]() {
                     // Implementation note: even if it seems superfluous, here
                     // we must add the scope otherwise the following call is
                     // going to fail because it's missing a scope.
@@ -214,7 +217,7 @@ template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
             self->nettest.on_end([
                 async_ctx = self->async_ctx, callback = wrap_callback(info[0])
             ]() {
-                UvAsyncCtx<>::suspend(async_ctx, [callback]() {
+                async::suspend<>(async_ctx, [callback]() {
                     Nan::HandleScope scope;
                     callback->Call(0, nullptr);
                 });
@@ -231,7 +234,7 @@ template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
             self->nettest.on_entry([
                 async_ctx = self->async_ctx, callback = wrap_callback(info[0])
             ](std::string s) {
-                UvAsyncCtx<>::suspend(async_ctx, [callback, s]() {
+                async::suspend<>(async_ctx, [callback, s]() {
                     Nan::HandleScope scope;
                     const int argc = 1;
                     v8::Local<v8::Value> argv[argc] = {
@@ -249,7 +252,7 @@ template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
             self->nettest.on_event([
                 async_ctx = self->async_ctx, callback = wrap_callback(info[0])
             ](const char *s) {
-                UvAsyncCtx<>::suspend(async_ctx, [
+                async::suspend<>(async_ctx, [
                         callback, s = std::string(s)
                 ]() {
                     Nan::HandleScope scope;
@@ -270,7 +273,7 @@ template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
             self->nettest.on_log([
                 async_ctx = self->async_ctx, callback = wrap_callback(info[0])
             ](uint32_t level, const char *s) {
-                UvAsyncCtx<>::suspend(
+                async::suspend<>(
                         async_ctx, [callback, level, s = std::string(s) ]() {
                     Nan::HandleScope scope;
                     const int argc = 2;
@@ -289,7 +292,7 @@ template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
             self->nettest.on_progress([
                 async_ctx = self->async_ctx, callback = wrap_callback(info[0])
             ](double percentage, const char *s) {
-                UvAsyncCtx<>::suspend(async_ctx, [
+                async::suspend<>(async_ctx, [
                         callback, percentage, s = std::string(s)
                 ]() {
                     Nan::HandleScope scope;
@@ -359,14 +362,14 @@ template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
         get_this(info)->nettest.on_destroy([
                 async_ctx = get_this(info)->async_ctx
         ]() {
-            UvAsyncCtx<>::start_delete(async_ctx);
+            async::start_delete(async_ctx);
         });
         if (argc >= 1) {
             get_this(info)->nettest.start([
                 async_ctx = get_this(info)->async_ctx,
                 callback = wrap_callback(info[0])
             ]() {
-                UvAsyncCtx<>::suspend(async_ctx, [callback]() {
+                async::suspend<>(async_ctx, [callback]() {
                     Nan::HandleScope scope;
                     callback->Call(0, nullptr);
                 });
@@ -374,10 +377,12 @@ template <typename Nettest> class NettestWrap : public Nan::ObjectWrap {
         } else {
             get_this(info)->nettest.run();
         }
+        // At this point we don't need to reference async_ctx anymore
+        get_this(info)->async_ctx.reset();
     }
 
     /// Async is the object used to route MK callbacks to libuv loop.
-    SharedPtr<UvAsyncCtx<>> async_ctx;
+    SharedPtr<async::Context> async_ctx;
 
     /// Nettest is the test we want to execute.
     Nettest nettest;

--- a/include/private/node/nettest_wrap.hpp
+++ b/include/private/node/nettest_wrap.hpp
@@ -4,7 +4,7 @@
 #ifndef PRIVATE_NODE_NETTEST_WRAP_HPP
 #define PRIVATE_NODE_NETTEST_WRAP_HPP
 
-#include "private/node/uv_async_ctx.hpp"
+#include "private/node/async.hpp"
 #include "private/node/wrap_callback.hpp"
 #include <measurement_kit/nettests.hpp>
 #include <nan.h>

--- a/include/private/node/uv_async_ctx.hpp
+++ b/include/private/node/uv_async_ctx.hpp
@@ -9,59 +9,56 @@
 #include <mutex>
 #include <uv.h>
 
-extern "C" {
-static inline void mkuv_resume(uv_async_t *async);
-static inline void mkuv_delete(uv_handle_t *handle);
-}
-
-namespace mk {
-namespace node {
-
-/// # UvAsyncCtx
+/// # async
 ///
 /// In the common case, MK callbacks are called in the context of an MK private
 /// background thread from which Node API cannot be called directly.
 ///
-/// UvAsyncCtx is the template class we use to schedule MK callbacks to execute
-/// in the context of libuv I/O loop (i.e. Node's I/O loop). The template
-/// arguments are libuv APIs, for testability. UvAsyncCtx<> is the template
-/// instance (hence the class) with default libuv APIs.
+/// `async` is the namespace that we use to schedule MK callbacks to execute
+/// in the context of libuv I/O loop (i.e. Node's I/O loop). It contains
+/// template functions whose arguments are libuv APIs, for testability. When
+/// we execute code in the common case we use as template arguments real
+/// libuv functions. In tests, we shall use mocked functions.
 ///
-/// You should call make() to get an instance of UvAsyncCtx<> allocated on the
+/// In this file we have only inline functions and template functions. We
+/// inline all the code because it's pretty small and having all inside of
+/// this private header in our opinion increases code readability.
+///
+/// You should call make<>() to get an instance of Context allocated on the
 /// heap and managed through SharedPtr, a null-safe shared pointer.
 ///
 /// ```C++
-///   SharedPtr<UvAsyncCtx<>> async = UvAsyncCtx<>::make().
+///   auto async_ctx = mk::node::async::make<>().
 /// ```
 ///
 /// When you register a callback for an MK test, copy the shared pointer into
 /// the lambda closure. When the callback is invoked by MK, you should call
-/// suspend() passing it a lambda in which closure you should store the arguments
+/// suspend<>() passing it a lambda in which closure you should store arguments
 /// received by MK's callback. Make sure that tempory arguments like pointers
 /// are made persistent to the lambda by creating copies. For example:
 ///
 /// ```C++
-///   test.on_log([async](uint32_t level, const char *s) {
-///       UvAsyncCtx<>::suspend(async, [level, msg = std::string(s)] {
+///   test.on_log([async_ctx](uint32_t level, const char *s) {
+///       mk::node::async::suspend<>(async_ctx, [level, msg = std::string(s)] {
 ///           // Here you can use level and msg with Node's C++ API.
 ///       });
 ///   });
 /// ```
 ///
-/// Internally, suspend() will wakeup the libuv loop. This means that eventually
-/// the suspended lambda will be called in the context of libuv loop. Inside
-/// such lambda you can safely call Node APIs.
+/// Internally, suspend<>() will wakeup the libuv loop. This means that
+/// eventually the suspended lambda will be called in the context of libuv
+/// loop. Inside such lambda you can safely call Node APIs.
 ///
-/// When you create an UvAsyncCtx<>, this will register a pointer to its
+/// When you create a Context, this will register a pointer to its
 /// `uv_async_t` field as a libuv handle with libuv's default loop. This implies
-/// that libuv's default loop will not exit as long as this handle is active. So
+/// that libuv's loop will not exit as long as this handle is active. So
 /// to avoid libuv's loop to run forever, we need to understand also how to
 /// unregister such handle when we are done.
 ///
 /// To understand that, we need to understand all the copies of the shared
 /// pointer that are keeping it alive. We have one copy for each callback
 /// we registered on the test (as shown above). Plus, we have one extra copy
-/// meant to represent the fact that libuv is using the UvAsyncCtx<>.
+/// meant to represent the fact that libuv is using the Context.
 ///
 /// In measurement-kit >= v0.8.0, the way in which we internally run the test
 /// should be such that, using the above pattern, the test should correctly
@@ -71,12 +68,12 @@ namespace node {
 /// To remove such last copy, register a `on_destroy` handler for the test. This
 /// will be triggered at the end of the test, as explained above. Pass to this
 /// method a lambda referencing the shared pointer. This lambda must call the
-/// start_delete() method. This method will internally make sure that libuv knows
-/// we don't need the async handle anymore and clean it up.
+/// start_delete() method. This method will internally make sure that libuv
+/// knows we don't need the async handle anymore and clean it up.
 ///
 /// ```C++
-///     test.on_destroy([async]() {
-///         UvAsyncWorker<>::StartDelete(async);
+///     test.on_destroy([async_ctx]() {
+///         mk::node::async:start_delete(async_ctx);
 ///     });
 /// ```
 ///
@@ -84,88 +81,34 @@ namespace node {
 /// correctly leave after the test is over. Otherwise, if you find Node stuck,
 /// the first thing you should check is whether the internal test object is
 /// actually destroyed (i.e. whether on_destroy is called).
+
+extern "C" {
+// Functions declared as extern C because the C++ FAQ recommends that the
+// code called from C must be as such to maximize portability.
+static inline void mkuv_resume(uv_async_t *handle);
+static inline void mkuv_delete(uv_handle_t *handle);
+}
+
+namespace mk {
+namespace node {
+namespace async {
+
+/// ## Context
 ///
-/// ## Methods
-template <MK_MOCK(uv_async_init), MK_MOCK(uv_async_send)> class UvAsyncCtx {
+/// Context is the class containing all the variables we need. It is a class
+/// because we only use `struct` in MK when it's a real piece of POD.
+///
+/// ### Fields
+class Context {
   public:
-    /// make() constructs an UvAsyncCtx<> instance.
-    static SharedPtr<UvAsyncCtx> make() {
-        SharedPtr<UvAsyncCtx> self{new UvAsyncCtx};
-        self->self = self; // Self reference modeling usage by libuv C code
-        self->async.data = self.get();
-        if (uv_async_init(uv_default_loop(), &self->async, mkuv_resume)) {
-            throw std::runtime_error("uv_async_init");
-        }
-        return self;
-    }
-
-    /// suspend() suspends the execution of `f` in the context of an MK thread
-    /// so that later it can be resumed in the context of libuv loop. As libuv
-    /// may coalesce multiple uv_async_send() calls, we use a list to keep track
-    /// of all the callbacks that need to be resumed. Of course, this method is
-    /// thread safe, since multiple threads can operate on the list. It is key
-    /// to move `f` so to give libuv's thread unique ownership.
-    static void suspend(
-            SharedPtr<UvAsyncCtx> self, std::function<void()> &&func) {
-        std::unique_lock<std::recursive_mutex> _{self->mutex};
-        self->suspended.push_back(std::move(func));
-        if (uv_async_send(&self->async) != 0) {
-            throw std::runtime_error("uv_async_send");
-        }
-    }
-
-    /// resume() is called by libuv loop to resume execution. The `async`
-    /// pointer used by libuv needs to be converted into an instance of the
-    /// UvAsyncCtx<> class. This method is also thread safe, since it needs
-    /// to extract from the list shared with MK threads. Also for thread
-    /// safety we use move semantic to remove from the list. (As in many other
-    /// parts of MK, we treat exceptions as unexpected, fatal errors and we
-    /// do not filter them.)
-    static void resume(uv_async_t *async) {
-        UvAsyncCtx *context = static_cast<UvAsyncCtx *>(async->data);
-        SharedPtr<UvAsyncCtx> self = context->self; // Until end of scope
-        std::list<std::function<void()>> functions;
-        {
-            std::unique_lock<std::recursive_mutex> _{self->mutex};
-            std::swap(self->suspended, functions);
-        }
-        for (auto &fn : functions) {
-            fn();
-        }
-    }
-
-    /// start_delete() initiates a delete operation of an UvAsyncCtx. We need to
-    /// suspend() because we have experimentally noticed that on Linux it will
-    /// not work if we call uv_close() from a non-libuv thread.
-    static void start_delete(SharedPtr<UvAsyncCtx> self) {
-        suspend(self, [self]() {
-            uv_close((uv_handle_t *)&self->async, mkuv_delete);
-        });
-    }
-
-    /// finish_delete() is called by libuv. We need to convert the generic
-    /// libuv `handle` pointer to a UvAsyncCtx instance.
-    static void finish_delete(uv_handle_t *handle) {
-        uv_async_t *async = reinterpret_cast<uv_async_t *>(handle);
-        UvAsyncCtx *context = static_cast<UvAsyncCtx *>(async->data);
-        SharedPtr<UvAsyncCtx> self = context->self; // Until end of scope
-        self->self = nullptr;
-    }
-
-  private:
-    /// The UvAsyncCtx() constructor is private to enforce usage of
-    /// this class through the make() factory.
-    UvAsyncCtx() {}
-
     /// The `async` structure is used to wakeup libuv's event loop and running
     /// callbacks in its context. Since uv_async_init() until finish_delete()
-    /// we must not delete the UvAsyncCtx class. The existence of a registered
+    /// we must not delete the Context class. The existence of a registered
     /// `uv_async_t *` will also prevent uv_loop() from exiting. We must init
     /// this field explicitly because it's a piece of POD.
     uv_async_t async{};
 
-    /// The mutex structure protects `suspended` and `async` (and possibly other
-    /// fields) from modification by concurrent threads of execution.
+    /// The mutex structure is used to make this class thread safe.
     std::recursive_mutex mutex;
 
     /// The suspended field is the list of suspended callbacks.
@@ -175,23 +118,89 @@ template <MK_MOCK(uv_async_init), MK_MOCK(uv_async_send)> class UvAsyncCtx {
     /// safely deleted. Libuv callbacks manipulating this class should
     /// keep a copy of self on the stack, for correctness, to enforce a
     /// lifecycle equal at least to the current scope.
-    SharedPtr<UvAsyncCtx> self;
+    ///
+    /// We could have used `std::enable_shared_from_this` but rather we
+    /// decided to have an always active shared pointer to really
+    /// gurantee that the object cannot be destroyed as long as the
+    /// underlying libevent loop is using it.
+    SharedPtr<Context> self;
 };
 
+/// make<>() constructs an Context instance. This function shall throw if an
+/// unrecoverable error occurs, as we do in other places in MK.
+template <MK_MOCK(uv_async_init)> static SharedPtr<Context> make() {
+    SharedPtr<Context> ctx{new Context};
+    ctx->self = ctx; // Self reference modeling usage by libuv C code
+    ctx->async.data = ctx.get();
+    if (uv_async_init(uv_default_loop(), &ctx->async, mkuv_resume)) {
+        throw std::runtime_error("uv_async_init");
+    }
+    return ctx;
+}
+
+/// suspend<>() suspends the execution of `f` in the context of an MK thread
+/// so that later it can be resumed in the context of libuv loop. As libuv
+/// may coalesce multiple uv_async_send() calls, we use a list to keep track
+/// of all the callbacks that need to be resumed. Of course, this method is
+/// thread safe, since multiple threads can operate on the list. It is key
+/// to move `f` so to give libuv's thread unique ownership.
+template <MK_MOCK(uv_async_send)>
+static void suspend(SharedPtr<Context> ctx, std::function<void()> &&func) {
+    std::unique_lock<std::recursive_mutex> _{ctx->mutex};
+    ctx->suspended.push_back(std::move(func));
+    if (uv_async_send(&ctx->async) != 0) {
+        throw std::runtime_error("uv_async_send");
+    }
+}
+
+/// start_delete() initiates a delete operation of an Context. We need to
+/// suspend() because we have experimentally noticed that on Linux it will
+/// not work if we call uv_close() from a non-libuv thread.
+///
+/// We cannot delete the context right away because we must need to wait
+/// for libuv to finish using it, which happens when mkuv_delete is called.
+static void start_delete(SharedPtr<Context> ctx) {
+    suspend(ctx,
+            [ctx]() { uv_close((uv_handle_t *)&ctx->async, mkuv_delete); });
+}
+
+} // namespace async
 } // namespace node
 } // namespace mk
 
-/// The mkuv_resume() C callback is called by libuv's I/O loop thread
-/// to resume execution of the suspended callbacks.
-static inline void mkuv_resume(uv_async_t *async) {
-    mk::node::UvAsyncCtx<>::resume(async);
+/// The mkuv_resume() C callback is called by libuv's I/O loop thread to resume
+/// execution of the suspended callbacks.
+///
+/// The `handle` pointer used by libuv needs to be converted into an instance of
+/// the Context class. This function is also thread safe, since it needs to
+/// extract from the list shared with MK threads. Also for thread safety we use
+/// move semantic to remove from the list. (As in many other parts of MK, we
+/// treat exceptions as fatal errors and we do not filter them.)
+static inline void mkuv_resume(uv_async_t *handle) {
+    using namespace mk::node::async;
+    using namespace mk;
+    Context *pctx = static_cast<Context *>(handle->data);
+    SharedPtr<Context> ctx = pctx->self; // Until end of scope, keep it safe
+    std::list<std::function<void()>> functions;
+    {
+        std::unique_lock<std::recursive_mutex> _{ctx->mutex};
+        std::swap(ctx->suspended, functions);
+    }
+    for (auto &fn : functions) {
+        fn(); // As said above, exception are fatal, so don't catch them
+    }
 }
 
 /// The mkuv_delete() C callback is called by libuv's I/O loop thread when
 /// libuv has successfully closed the async handle, to tell us that now it's
 /// safe to dispose of the memory associated with such handle.
 static inline void mkuv_delete(uv_handle_t *handle) {
-    mk::node::UvAsyncCtx<>::finish_delete(handle);
+    using namespace mk::node::async;
+    using namespace mk;
+    uv_async_t *async_handle = reinterpret_cast<uv_async_t *>(handle);
+    Context *pctx = static_cast<Context *>(async_handle->data);
+    SharedPtr<Context> ctx;
+    std::swap(ctx, pctx->self); // Remove ref and keep alive until end of scope
 }
 
 #endif


### PR DESCRIPTION
@hellais I recommend looking into each commit on it own. Detail of changes:

- stop using the pattern where we have a class composed only of static method as this is typically something that is frowned upon by C++ programmers

- rename the specific header so that it's more obviously discoverable by someone casually reading the code

- use a more obvious pattern to guarantee that we're keeping alive the object: rather than having a self referencing pointer, use instead a dynamically allocated shared pointer passed to C code

Perhaps more refactoring can be implemented in the future, but for now this seems to me a good move forward to make the code in here more obvious.

After this is merged, I can move on with making sure we wrap all we need to wrap.